### PR TITLE
Make example compiles right away (by setting Slack config to empty string)

### DIFF
--- a/sample_test/src/main/java/com/cookpad/okreport/OkReportApp.kt
+++ b/sample_test/src/main/java/com/cookpad/okreport/OkReportApp.kt
@@ -26,10 +26,14 @@ class OkReportApp : Application() {
         lateinit var okReport: OkReport
     }
 
+    val slackToken = ""
+    val slackWebhookURL = ""
+    val slackNameChannelImages = ""
+
     override fun onCreate() {
         super.onCreate()
 
-        val slackReporter = SlackReporter(token, webhookURL, collectDeviceSpecs(this), nameChannelImages, notifyChannel = false)
+        val slackReporter = SlackReporter(slackToken, slackWebhookURL, collectDeviceSpecs(this), slackNameChannelImages, notifyChannel = false)
         val okReport = initOkReport(this, slackReporter)
 
         ShakeGesture(this).apply {

--- a/slack_reporter/src/main/java/com/cookpad/slack_reporter/SlackReporter.kt
+++ b/slack_reporter/src/main/java/com/cookpad/slack_reporter/SlackReporter.kt
@@ -40,6 +40,8 @@ import org.json.JSONObject
 class SlackReporter(val token: String, val webhookURL: String, val deviceSpecs: DeviceSpecs,
                     val idOrNameChannelImages: String, val notifyChannel: Boolean = false) : Reporter {
     override fun sendReport(report: Report, reporterCallback: ReporterCallback) {
+        returnIfEmptyConfig(reporterCallback)
+
         val asyncTask = object : AsyncTask<String, Void, Response>() {
 
             override fun doInBackground(vararg ignored: String): Response {
@@ -66,6 +68,13 @@ class SlackReporter(val token: String, val webhookURL: String, val deviceSpecs: 
         }
 
         asyncTask.execute("")
+    }
+
+    inline private fun returnIfEmptyConfig(reporterCallback: ReporterCallback) {
+        if (token.isEmpty() || webhookURL.isEmpty() || idOrNameChannelImages.isEmpty()) {
+            reporterCallback.error(Throwable("Looks like you forgot to setup your Slack configuration. Check this https://github.com/cookpad/OkReport#init-and-configire-okreport"))
+            return
+        }
     }
 }
 


### PR DESCRIPTION
### Overview
This PR is to make the sample project compile right away. I defaulted all the Slack string to `""`, and change the `SlackReporter` to send error about empty configuration.

So the sample project compiles right away, and developers can try this project without setting up Slack. 

But of course, they will see the following error when they hit the **send button**.
![recording mp4](https://user-images.githubusercontent.com/1988156/29355659-da8cff80-82ac-11e7-8c89-4b849e8cad89.gif)

Once they've decided that they want to try out more, they can eventually setup.

